### PR TITLE
Multiplayer: prevent time travel

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -37,14 +37,13 @@ class App extends Component {
     constructor() {
         super()
         // 🐛 BUGOUT 🐞
-        let bugoutPlayerColor = window.confirm("Press Cancel for White, Press OK for Black") ? "B" : "W"
+        this.bugoutPlayerColor = window.confirm("Press Cancel for White, Press OK for Black") ? "B" : "W"
 
         window.sabaki = this
 
         let emptyTree = gametree.new()
 
         this.state = {
-            bugoutPlayerColor, // 🐛 BUGOUT 🐞
             mode: 'play',
             openDrawer: null,
             busy: 0,
@@ -2194,7 +2193,7 @@ class App extends Component {
     // 🐛 BUGOUT 🐞 BELOW 🕷
     attachBugout() {
         let bugoutEngine = {"name":"Opponent", "path":"/bugout", "args": ""}
-        if (this.state.bugoutPlayerColor === "W") {
+        if (this.bugoutPlayerColor === "W") {
             this.attachEngines(bugoutEngine, null)
         } else {
             this.attachEngines(null,bugoutEngine)
@@ -2203,7 +2202,7 @@ class App extends Component {
     // 🐛 BUGOUT 🐞 BELOW 🕷
     startBugout() {
         const STARTUP_WAIT_MS = 1333
-        if (this.state.bugoutPlayerColor === "W") {
+        if (this.bugoutPlayerColor === "W") {
             setTimeout(
                 () => this.generateMove({ firstMove: true }),
                 STARTUP_WAIT_MS)

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -759,7 +759,6 @@ class App extends Component {
 
     clickVertex(vertex, {button = 0, ctrlKey = false, x = 0, y = 0} = {}) {
         this.closeDrawer()
-        this.goToEnd() // 🐞BUGOUT🐛
 
         let t = i18n.context('app.play')
         let {gameTrees, gameIndex, gameCurrents, treePosition} = this.state

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -37,13 +37,14 @@ class App extends Component {
     constructor() {
         super()
         // 🐛 BUGOUT 🐞
-        this.bugoutPlayerColor = window.confirm("Press Cancel for White, Press OK for Black") ? "B" : "W"
+        let bugoutPlayerColor = window.confirm("Press Cancel for White, Press OK for Black") ? "B" : "W"
 
         window.sabaki = this
 
         let emptyTree = gametree.new()
 
         this.state = {
+            bugoutPlayerColor, // 🐛 BUGOUT 🐞
             mode: 'play',
             openDrawer: null,
             busy: 0,
@@ -759,6 +760,7 @@ class App extends Component {
 
     clickVertex(vertex, {button = 0, ctrlKey = false, x = 0, y = 0} = {}) {
         this.closeDrawer()
+        this.goToEnd() // 🐞BUGOUT🐛
 
         let t = i18n.context('app.play')
         let {gameTrees, gameIndex, gameCurrents, treePosition} = this.state
@@ -2192,7 +2194,7 @@ class App extends Component {
     // 🐛 BUGOUT 🐞 BELOW 🕷
     attachBugout() {
         let bugoutEngine = {"name":"Opponent", "path":"/bugout", "args": ""}
-        if (this.bugoutPlayerColor === "W") {
+        if (this.state.bugoutPlayerColor === "W") {
             this.attachEngines(bugoutEngine, null)
         } else {
             this.attachEngines(null,bugoutEngine)
@@ -2201,7 +2203,7 @@ class App extends Component {
     // 🐛 BUGOUT 🐞 BELOW 🕷
     startBugout() {
         const STARTUP_WAIT_MS = 1333
-        if (this.bugoutPlayerColor === "W") {
+        if (this.state.bugoutPlayerColor === "W") {
             setTimeout(
                 () => this.generateMove({ firstMove: true }),
                 STARTUP_WAIT_MS)

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -73,7 +73,7 @@ class App extends Component {
             playVariation: null,
             showCoordinates: null,
             showMoveColorization: null,
-            showMoveNumbers: null,
+            showMoveNumbers: setting.get('view.show_move_numbers'), // 😇BUGOUT😇
             showNextMoves: null,
             showSiblings: null,
             fuzzyStonePlacement: null,
@@ -84,9 +84,9 @@ class App extends Component {
             consoleLog: [],
             showConsole: setting.get('view.show_leftsidebar'),
             leftSidebarWidth: setting.get('view.leftsidebar_width'),
-            showGameGraph: setting.get('view.show_graph'),
+            showGameGraph: false, // 😇BUGOUT😇
             showCommentBox: setting.get('view.show_comments'),
-            sidebarWidth: setting.get('view.sidebar_width'),
+            sidebarWidth: 120, // 😇BUGOUT😇
             graphGridSize: null,
             graphNodeSize: null,
 

--- a/src/components/bars/PlayBar.js
+++ b/src/components/bars/PlayBar.js
@@ -56,6 +56,11 @@ class PlayBar extends Component {
                     click: () => toggleSetting('view.show_coordinates')
                 },
                 {
+                    label: t('Show Move Numbers'),
+                    checked: setting.get('view.show_move_numbers'),
+                    click: () => toggleSetting('view.show_move_numbers')
+                },
+                {
                     label: t('Show Move Colori&zation'),
                     checked: setting.get('view.show_move_colorization'),
                     click: () => toggleSetting('view.show_move_colorization')

--- a/src/modules/bugout.js
+++ b/src/modules/bugout.js
@@ -1,8 +1,0 @@
-exports.safeMoveNumber = 
-    (playerLetter, moveNumber) => {
-        if ((playerLetter === "B" && moveNumber % 2) 
-            || (playerLetter === "W" && !(moveNumber % 2)))
-            return moveNumber
-            
-        return moveNumber - 1
-    }

--- a/src/modules/bugout.js
+++ b/src/modules/bugout.js
@@ -1,0 +1,8 @@
+exports.safeMoveNumber = 
+    (playerLetter, moveNumber) => {
+        if ((playerLetter === "B" && moveNumber % 2) 
+            || (playerLetter === "W" && !(moveNumber % 2)))
+            return moveNumber
+            
+        return moveNumber - 1
+    }


### PR DESCRIPTION
Hides the game graph, shrinks the editor, and allows the player to expose move numbers on pieces via the menu.