### PR TITLE
Multiplayer: add game lobby & color chooser plumbing🚰

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -672,7 +672,8 @@ class App extends Component {
             this.detachEngines()
             this.clearConsole()
 
-            this.bugout.attach((a, b) => this.attachEngines(a,b))
+            // TODO
+            //this.bugout.attach((a, b) => this.attachEngines(a,b))
 
             this.setState({
                 representedFilename: null,
@@ -2525,6 +2526,18 @@ class App extends Component {
         }
 
         state = Object.assign(state, this.inferredState)
+
+        if (this.bugout.readyToEnter(state)) {
+            this.setState({ multiplayer: { initConnect: bugout.InitConnected.IN_PROGRESS}})
+            this.bugout.attach((a, b) => { 
+                this.attachEngines(a,b); 
+                if (this.state.attachedEngines === [null, null]) {
+                    this.setState({ multiplayer: { initConnect: bugout.InitConnected.FAILED}})
+                } else {
+                    this.setState({ multiplayer: { initConnect: bugout.InitConnected.CONNECTED}})
+                }       
+            })
+        }
 
         return h('section',
             {

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -2539,10 +2539,9 @@ class App extends Component {
                         this.setState({ multiplayer: { initConnect: bugout.InitConnected.FAILED}})
                         console.log(`multiplayer connect failed`)
                     } else {
-                        this.setState({ multiplayer: { initConnect: bugout.InitConnected.CONNECTED}})
-                        console.log(`multiplayer connect succeeded`)                        
+                        this.setState({ multiplayer: { initConnect: bugout.InitConnected.CONNECTED}})                      
                     }    
-                }   catch(e) {
+                } catch(e) {
                     console.log(` ERROR !  ${e}`)
                 }
             })

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -276,8 +276,8 @@ class App extends Component {
             evt.returnValue = ' '
         })
 
-        // TODO thisn good?
-        this.newFile().then(() => this.bugout.start(() => this.generateMove({ firstMove: true })))
+        // TODO bye bye
+        this.newFile()
     }
 
     componentDidUpdate(_, prevState = {}) {
@@ -2526,28 +2526,40 @@ class App extends Component {
         state = Object.assign(state, this.inferredState)
 
         if (this.bugout.readyToEnter(state)) {
+            console.log('hey everybody')
             this.setState({ multiplayer: { initConnect: bugout.InitConnected.IN_PROGRESS}})
             this.detachEngines()
             this.clearConsole()
+            let playerColor = this.bugout.prefToColor(state.multiplayer.colorPref)
             this.bugout.attach((a, b) => {
-                try {
-                    this.attachEngines(a,b); 
-                    if (this.state.attachedEngines === [null, null]) {
-                        this.setState({ multiplayer: { initConnect: bugout.InitConnected.FAILED}})
-                        console.log(`multiplayer connect failed`)
-                    } else {
-                        this.setState({ multiplayer: { initConnect: bugout.InitConnected.CONNECTED}})
-                        if (this.state.multiplayer && this.state.multiplayer.provideHistory) {
-                            this.setState({ multiplayer: { provideHistory: undefined } } )
-                            // TODO or thisn good?
-                            this.generateMove({ firstMove: true })
-                        }   
-                    }    
-                } catch(e) {
-                    console.log(` ERROR !  ${e}`)
+                this.attachEngines(a, b)
+
+                if (this.state.attachedEngines === [null, null]) {
+                    this.setState({ multiplayer: { initConnect: bugout.InitConnected.FAILED}})
+                    console.log(`multiplayer connect failed`)
+                } else {
+                    console.log('HEY')
+                    this.setState({ multiplayer: { initConnect: bugout.InitConnected.CONNECTED}})
+                    console.log('HI')
+                    if (this.state.multiplayer && this.state.multiplayer.provideHistory) {
+                        this.setState({ multiplayer: { provideHistory: undefined } } )
+                        console.log('YOOO')
+                        // TODO or thisn good?
+                        if (playerColor == bugout.Color.WHITE) {
+                            console.log('the w')
+                            setTimeout(
+                                () => this.generateMove({ firstMove: true }),
+                                1333)
+                        }
+                    }
                 }
-            })
+            }, playerColor) // not undefined since we're readyToEnter
+            
+        } else {
+            console.log('NOPE')
         }
+        
+        
 
         return h('section',
             {
@@ -2558,8 +2570,24 @@ class App extends Component {
                 })
             },
 
-            h(GameLobbyModal, { joinPrivateGame: this.bugout.joinPrivateGame.join }),
-            h(ColorChoiceModal, {turnOn: state.multiplayer && state.multiplayer.initConnect && state.multiplayer.initConnect === bugout.InitConnected.CONNECTED}), // BUGOUT
+            h(GameLobbyModal, {
+                joinPrivateGame: this.bugout.joinPrivateGame.join,
+                update: visibility => this.setState({ 
+                    multiplayer: {
+                        ...this.state.multiplayer,
+                        visibility
+                    }
+                })
+            }),
+            h(ColorChoiceModal, {
+                turnOn: state.multiplayer && state.multiplayer.visibility,
+                updatePref: colorPref => this.setState({
+                    multiplayer: {
+                        ...this.state.multiplayer,
+                        colorPref
+                    }
+                })
+            }), // BUGOUT
 
             h(ThemeManager),
             h(MainView, state),

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -2552,7 +2552,7 @@ class App extends Component {
                 })
             },
 
-            h(GameLobbyModal, { joinPrivateGame: this.bugout.joinPrivateGame.join }), // BUGOUT
+            h(GameLobbyModal, { joinPrivateGame: this.bugout.joinPrivateGame.join }),
 
             h(ThemeManager),
             h(MainView, state),

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -2525,18 +2525,35 @@ class App extends Component {
         state = Object.assign(state, this.inferredState)
 
         if (this.bugout.readyToEnter(state)) {
-            this.setState({ multiplayer: { initConnect: bugout.InitConnected.IN_PROGRESS}})
+            this.setState({
+                multiplayer: {
+                    ...this.state.multiplayer,
+                    initConnect: bugout.InitConnected.IN_PROGRESS
+                }
+            })
+            
             this.detachEngines()
             this.clearConsole()
+
             let playerColor = this.bugout.prefToColor(state.multiplayer.colorPref)
             this.bugout.attach((a, b) => {
                 this.attachEngines(a, b)
 
                 if (this.state.attachedEngines === [null, null]) {
-                    this.setState({ multiplayer: { ...this.state.multiplayer, initConnect: bugout.InitConnected.FAILED}})
+                    this.setState({
+                        multiplayer: {
+                            ...this.state.multiplayer,
+                            initConnect: bugout.InitConnected.FAILED
+                        }
+                    })
                     console.log(`multiplayer connect failed`)
                 } else {
-                    this.setState({ multiplayer: { ...this.state.multiplayer, initConnect: bugout.InitConnected.CONNECTED}})
+                    this.setState({
+                        multiplayer: {
+                            ...this.state.multiplayer,
+                            initConnect: bugout.InitConnected.CONNECTED
+                        }
+                    })
                     if (this.state.multiplayer && playerColor === bugout.Color.WHITE) {
                         if (playerColor == bugout.Color.WHITE) {
                             let waitMs = 1333
@@ -2548,11 +2565,7 @@ class App extends Component {
                 }
             }, playerColor) // not undefined since we're readyToEnter
             
-        } else {
-            console.log('NOPE')
         }
-        
-        
 
         return h('section',
             {

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -2530,6 +2530,8 @@ class App extends Component {
 
         if (this.bugout.readyToEnter(state)) {
             this.setState({ multiplayer: { initConnect: bugout.InitConnected.IN_PROGRESS}})
+            this.detachEngines()
+            this.clearConsole()
             this.bugout.attach((a, b) => {
                 try {
                     this.attachEngines(a,b); 

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -2558,7 +2558,6 @@ class App extends Component {
                 })
             },
 
-
             h(GameLobbyModal, { joinPrivateGame: this.bugout.joinPrivateGame.join }), // BUGOUT
 
             h(ThemeManager),

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -275,7 +275,8 @@ class App extends Component {
             evt.returnValue = ' '
         })
 
-        this.newFile().then(_n => 
+        // TODO bugout ... ?
+        this.newFile().then(_n =>
             this.bugout.start(() => this.generateMove({ firstMove: true })))
     }
 
@@ -2529,13 +2530,19 @@ class App extends Component {
 
         if (this.bugout.readyToEnter(state)) {
             this.setState({ multiplayer: { initConnect: bugout.InitConnected.IN_PROGRESS}})
-            this.bugout.attach((a, b) => { 
-                this.attachEngines(a,b); 
-                if (this.state.attachedEngines === [null, null]) {
-                    this.setState({ multiplayer: { initConnect: bugout.InitConnected.FAILED}})
-                } else {
-                    this.setState({ multiplayer: { initConnect: bugout.InitConnected.CONNECTED}})
-                }       
+            this.bugout.attach((a, b) => {
+                try {
+                    this.attachEngines(a,b); 
+                    if (this.state.attachedEngines === [null, null]) {
+                        this.setState({ multiplayer: { initConnect: bugout.InitConnected.FAILED}})
+                        console.log(`multiplayer connect failed`)
+                    } else {
+                        this.setState({ multiplayer: { initConnect: bugout.InitConnected.CONNECTED}})
+                        console.log(`multiplayer connect succeeded`)                        
+                    }    
+                }   catch(e) {
+                    console.log(` ERROR !  ${e}`)
+                }
             })
         }
 

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -672,9 +672,6 @@ class App extends Component {
             this.detachEngines()
             this.clearConsole()
 
-            // TODO
-            //this.bugout.attach((a, b) => this.attachEngines(a,b))
-
             this.setState({
                 representedFilename: null,
                 gameIndex: 0,

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -275,9 +275,6 @@ class App extends Component {
             evt.returnValue = ' '
         })
 
-        /*if (this.bugout.joinPrivateGame.join) {
-            this.setState({multiplayer: { visibility: bugout.Visibility.PRIVATE }})
-        }*/
         this.newFile().then(_n =>
             this.bugout.start(() => this.generateMove({ firstMove: true })))
     }

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -2541,10 +2541,7 @@ class App extends Component {
                     console.log('HEY')
                     this.setState({ multiplayer: { initConnect: bugout.InitConnected.CONNECTED}})
                     console.log('HI')
-                    if (this.state.multiplayer && this.state.multiplayer.provideHistory) {
-                        this.setState({ multiplayer: { provideHistory: undefined } } )
-                        console.log('YOOO')
-                        // TODO or thisn good?
+                    if (this.state.multiplayer && playerColor === bugout.Color.WHITE) {
                         if (playerColor == bugout.Color.WHITE) {
                             console.log('the w')
                             setTimeout(

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -2539,10 +2539,10 @@ class App extends Component {
                     this.setState({ multiplayer: { ...this.state.multiplayer, initConnect: bugout.InitConnected.CONNECTED}})
                     if (this.state.multiplayer && playerColor === bugout.Color.WHITE) {
                         if (playerColor == bugout.Color.WHITE) {
-                            console.log('the w')
+                            let waitMs = 1333
                             setTimeout(
                                 () => this.generateMove({ firstMove: true }),
-                                1333)
+                                waitMs)
                         }
                     }
                 }

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -275,8 +275,8 @@ class App extends Component {
             evt.returnValue = ' '
         })
 
-        this.newFile().then(_n =>
-            this.bugout.start(() => this.generateMove({ firstMove: true })))
+        // TODO thisn good?
+        this.newFile().then(() => this.bugout.start(() => this.generateMove({ firstMove: true })))
     }
 
     componentDidUpdate(_, prevState = {}) {
@@ -2535,7 +2535,12 @@ class App extends Component {
                         this.setState({ multiplayer: { initConnect: bugout.InitConnected.FAILED}})
                         console.log(`multiplayer connect failed`)
                     } else {
-                        this.setState({ multiplayer: { initConnect: bugout.InitConnected.CONNECTED}})                      
+                        this.setState({ multiplayer: { initConnect: bugout.InitConnected.CONNECTED}})
+                        if (this.state.multiplayer && this.state.multiplayer.provideHistory) {
+                            this.setState({ multiplayer: { provideHistory: undefined } } )
+                            // TODO or thisn good?
+                            this.generateMove({ firstMove: true })
+                        }   
                     }    
                 } catch(e) {
                     console.log(` ERROR !  ${e}`)

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -2525,7 +2525,6 @@ class App extends Component {
         state = Object.assign(state, this.inferredState)
 
         if (this.bugout.readyToEnter(state)) {
-            console.log('hey everybody')
             this.setState({ multiplayer: { initConnect: bugout.InitConnected.IN_PROGRESS}})
             this.detachEngines()
             this.clearConsole()
@@ -2534,12 +2533,10 @@ class App extends Component {
                 this.attachEngines(a, b)
 
                 if (this.state.attachedEngines === [null, null]) {
-                    this.setState({ multiplayer: { initConnect: bugout.InitConnected.FAILED}})
+                    this.setState({ multiplayer: { ...this.state.multiplayer, initConnect: bugout.InitConnected.FAILED}})
                     console.log(`multiplayer connect failed`)
                 } else {
-                    console.log('HEY')
-                    this.setState({ multiplayer: { initConnect: bugout.InitConnected.CONNECTED}})
-                    console.log('HI')
+                    this.setState({ multiplayer: { ...this.state.multiplayer, initConnect: bugout.InitConnected.CONNECTED}})
                     if (this.state.multiplayer && playerColor === bugout.Color.WHITE) {
                         if (playerColor == bugout.Color.WHITE) {
                             console.log('the w')

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -276,7 +276,6 @@ class App extends Component {
             evt.returnValue = ' '
         })
 
-        // TODO bye bye
         this.newFile()
     }
 

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -275,7 +275,9 @@ class App extends Component {
             evt.returnValue = ' '
         })
 
-        // TODO bugout ... ?
+        /*if (this.bugout.joinPrivateGame.join) {
+            this.setState({multiplayer: { visibility: bugout.Visibility.PRIVATE }})
+        }*/
         this.newFile().then(_n =>
             this.bugout.start(() => this.generateMove({ firstMove: true })))
     }
@@ -2557,7 +2559,7 @@ class App extends Component {
             },
 
 
-            h(GameLobbyModal), // BUGOUT
+            h(GameLobbyModal, { joinPrivateGame: this.bugout.joinPrivateGame.join }), // BUGOUT
 
             h(ThemeManager),
             h(MainView, state),

--- a/src/components/ColorChoiceModal.js
+++ b/src/components/ColorChoiceModal.js
@@ -1,7 +1,7 @@
 const { h, Component } = require('preact')
 
 const { Dialog } = require('preact-material-components')
-
+const { ColorPref } = require('../modules/bugout')
 
 class ColorChoiceModal extends Component {
     constructor() {
@@ -9,7 +9,7 @@ class ColorChoiceModal extends Component {
         this.state = { showDialog: false, turnedOnOnce: false }
     }
 
-    render({ id = "color-choice-modal", turnOn = false }) {
+    render({ id = "color-choice-modal", turnOn = false, updatePref }) {
         let { showDialog, turnedOnOnce } = this.state
       
         return ((turnOn && !turnedOnOnce) || showDialog) ? h(Dialog,
@@ -25,7 +25,7 @@ class ColorChoiceModal extends Component {
                         accept: true, 
                         onClick: () => {
                             this.setState({showDialog: false, turnedOnOnce: true })
-                            // 🚧 Not Implemented 🚧
+                            updatePref( ColorPref.BLACK )
                         }
                     }, 
                     "Black")
@@ -36,18 +36,9 @@ class ColorChoiceModal extends Component {
                         cancel: true,
                         onClick: () => {
                             this.setState({showDialog: false, turnedOnOnce: true })
-                            // 🚧 Not Implemented 🚧
+                            updatePref( ColorPref.WHITE )
                         }
-                    }, "White")),
-            h(Dialog.Footer, null, 
-                h(Dialog.FooterButton, 
-                    { 
-                        cancel: true,
-                        onClick: () => {
-                            this.setState({showDialog: false, turnedOnOnce: true })
-                            // 🚧 Not Implemented 🚧
-                        }
-                    }, "Any"))
+                    }, "White"))
         ) : h('div', { id })
     }
 }

--- a/src/components/ColorChoiceModal.js
+++ b/src/components/ColorChoiceModal.js
@@ -18,7 +18,7 @@ class ColorChoiceModal extends Component {
                 isOpen: true,
             },
             h(Dialog.Header, null, 'Choose a Color'),
-            h(Dialog.Body, null, 'We reserve the right to assign colors arbitrarily.'),
+            h(Dialog.Body, null, "We're on the honor system, for now.  If you choose the same color as your opponent, we apologize."),
             h(Dialog.Footer, null, 
                 h(Dialog.FooterButton, 
                     { 

--- a/src/components/GameLobbyModal.js
+++ b/src/components/GameLobbyModal.js
@@ -12,7 +12,7 @@ class GameLobbyModal extends Component {
 
     render({ id = "game-lobby-modal" }) {
         
-        return  this.state.showDialog ? h(Dialog,
+        return  (this.state.showDialog) ? h(Dialog,
             {
                 id,
                 isOpen: true,

--- a/src/components/GameLobbyModal.js
+++ b/src/components/GameLobbyModal.js
@@ -11,7 +11,6 @@ class GameLobbyModal extends Component {
     }
 
     render({ id = "game-lobby-modal", joinPrivateGame = false }) {
-        console.log(`is it secret? is it safe? 💍 ${joinPrivateGame}`)
         if (joinPrivateGame && this.state.showDialog) {
             return h(Dialog,
                 {

--- a/src/components/GameLobbyModal.js
+++ b/src/components/GameLobbyModal.js
@@ -48,7 +48,12 @@ class GameLobbyModal extends Component {
                         onClick: () => {
                             this.setState({showDialog: false})
                             // CAUTION - GLOBAL STATE AHEAD
-                            sabaki.setState({ multiplayer: { visibility: Visibility.PUBLIC } })
+                            sabaki.setState({
+                                multiplayer: {
+                                    visibility: Visibility.PUBLIC,
+                                    provideHistory: true
+                                }
+                            })
                         }
                     }, 
                     "Public")
@@ -60,7 +65,12 @@ class GameLobbyModal extends Component {
                         onClick: () => {
                             this.setState({showDialog: false})
                             // CAUTION - GLOBAL STATE AHEAD
-                            sabaki.setState({ multiplayer: { visibility: Visibility.PRIVATE } })
+                            sabaki.setState({
+                                multiplayer: {
+                                    visibility: Visibility.PRIVATE,
+                                    provideHistory: true
+                                }
+                            })
                         }
                     }, "Private"))
         ) : h('div', { id })

--- a/src/components/GameLobbyModal.js
+++ b/src/components/GameLobbyModal.js
@@ -10,8 +10,31 @@ class GameLobbyModal extends Component {
         this.state = { showDialog: true }
     }
 
-    render({ id = "game-lobby-modal" }) {
-        
+    render({ id = "game-lobby-modal", joinPrivateGame = false }) {
+        console.log(`is it secret? is it safe? 💍 ${joinPrivateGame}`)
+        if (joinPrivateGame && this.state.showDialog) {
+            return h(Dialog,
+                {
+                    id,
+                    isOpen: true,
+                },
+                h(Dialog.Header, null, "Join Private Game"),
+                h(Dialog.Body, null, "You're joining a private game created by your friend."),
+                h(Dialog.Footer, null, 
+                    h(Dialog.FooterButton, 
+                        { 
+                            accept: true, 
+                            onClick: () => {
+                                this.setState({showDialog: false})
+                                // CAUTION - GLOBAL STATE AHEAD
+                                sabaki.setState({ multiplayer: { visibility: Visibility.PRIVATE } })
+                            }
+                        }, 
+                        "OK")
+                    )
+            )
+        }
+
         return  (this.state.showDialog) ? h(Dialog,
             {
                 id,

--- a/src/components/GameLobbyModal.js
+++ b/src/components/GameLobbyModal.js
@@ -25,8 +25,7 @@ class GameLobbyModal extends Component {
                             accept: true, 
                             onClick: () => {
                                 this.setState({showDialog: false})
-                                // CAUTION - GLOBAL STATE AHEAD
-                                update( Visibility.PRIVATE )
+                                update(Visibility.PRIVATE)
                             }
                         }, 
                         "OK")

--- a/src/components/GameLobbyModal.js
+++ b/src/components/GameLobbyModal.js
@@ -10,7 +10,7 @@ class GameLobbyModal extends Component {
         this.state = { showDialog: true }
     }
 
-    render({ id = "game-lobby-modal", joinPrivateGame = false }) {
+    render({ id = "game-lobby-modal", joinPrivateGame = false, update }) {
         if (joinPrivateGame && this.state.showDialog) {
             return h(Dialog,
                 {
@@ -26,7 +26,7 @@ class GameLobbyModal extends Component {
                             onClick: () => {
                                 this.setState({showDialog: false})
                                 // CAUTION - GLOBAL STATE AHEAD
-                                sabaki.setState({ multiplayer: { visibility: Visibility.PRIVATE } })
+                                update( Visibility.PRIVATE )
                             }
                         }, 
                         "OK")
@@ -47,13 +47,7 @@ class GameLobbyModal extends Component {
                         accept: true, 
                         onClick: () => {
                             this.setState({showDialog: false})
-                            // CAUTION - GLOBAL STATE AHEAD
-                            sabaki.setState({
-                                multiplayer: {
-                                    visibility: Visibility.PUBLIC,
-                                    provideHistory: true
-                                }
-                            })
+                            update(Visibility.PUBLIC)
                         }
                     }, 
                     "Public")
@@ -64,13 +58,7 @@ class GameLobbyModal extends Component {
                         cancel: true,
                         onClick: () => {
                             this.setState({showDialog: false})
-                            // CAUTION - GLOBAL STATE AHEAD
-                            sabaki.setState({
-                                multiplayer: {
-                                    visibility: Visibility.PRIVATE,
-                                    provideHistory: true
-                                }
-                            })
+                            update(Visibility.PRIVATE)
                         }
                     }, "Private"))
         ) : h('div', { id })

--- a/src/modules/bugout.js
+++ b/src/modules/bugout.js
@@ -32,14 +32,14 @@ const Color = {
 }
 
 /** private to isValidGameId */
-const MIN_ID_LENGTH = 18
+const MIN_ID_LENGTH = 4
 /** private to isValidGameId */
-const MAX_ID_LENGTH = 37
+const MAX_ID_LENGTH = 30
 /** private to isValidGameId */
 const re = new RegExp(/^[a-zA-Z0-9]+$/, 'm')
 
 const isValidGameId = p =>
-    p && p.length > MIN_ID_LENGTH && p.length < MAX_ID_LENGTH && re.test(p)
+    p && p.length >= MIN_ID_LENGTH && p.length <= MAX_ID_LENGTH && re.test(p)
 
 const joinPrivateGameParam = () => {
     let urlParams = new URLSearchParams(window.location.search)

--- a/src/modules/bugout.js
+++ b/src/modules/bugout.js
@@ -66,8 +66,17 @@ const load = () => {
                 appAttachEngines(null,engine)
             }
         },
-        readyToEnter: state =>
-            state.multiplayer && state.multiplayer.initConnect < InitConnected.IN_PROGRESS && (state.multiplayer.visibility || jp.join)
+        readyToEnter: state => {
+            if (state.multiplayer) {
+                console.log(`ok ${state.multiplayer.initConnect}`)
+            } else {
+                console.log('NOPE')
+            }
+            return state.multiplayer && (
+                state.multiplayer.initConnect == undefined || 
+                state.multiplayer.initConnect < InitConnected.IN_PROGRESS
+                ) && (state.multiplayer.visibility || jp.join)
+        }
     };
 }
 

--- a/src/modules/bugout.js
+++ b/src/modules/bugout.js
@@ -1,7 +1,31 @@
-const re = new RegExp(/^[a-zA-Z0-9]+$/, 'm')
+/**
+ * Enum representing game visibility
+ */
+const Visibility = {
+    PUBLIC: 1,
+    PRIVATE: 2,
+}
 
+/**
+ * Enum representing the status of an initial connection
+ * attempt from Sabaki client to Bugout gateway
+ */
+const InitConnected = {
+    DISCONNECTED: 0,
+    IN_PROGRESS: 1,
+    CONNECTED: 2,
+    FAILED: 3,
+}
+
+const BLACK = "B"
+const WHITE = "W"
+
+/** private to isValidGameId */
 const MIN_ID_LENGTH = 18
+/** private to isValidGameId */
 const MAX_ID_LENGTH = 37
+/** private to isValidGameId */
+const re = new RegExp(/^[a-zA-Z0-9]+$/, 'm')
 
 const isValidGameId = p =>
     p && p.length > MIN_ID_LENGTH && p.length < MAX_ID_LENGTH && re.test(p)
@@ -16,22 +40,15 @@ const joinPrivateGameParam = () => {
     }
 }
 
-const BLACK = "B"
-const WHITE = "W"
-
 const playerColor = () => 
     window.confirm("Press Cancel for White, Press OK for Black") ? BLACK : WHITE
-
-const Visibility = {
-    PUBLIC: 1,
-    PRIVATE: 2,
-}
 
 const load = () => {
     let pc = playerColor()
     let engine = {"name":"Opponent", "path":"/bugout", "args": ""}
+    let jp = joinPrivateGameParam()
     return {
-        joinPrivateGame: joinPrivateGameParam(),
+        joinPrivateGame: jp,
         playerColor: pc,
         start: (cb) => {
             const STARTUP_WAIT_MS = 1333
@@ -48,9 +65,12 @@ const load = () => {
             } else {
                 appAttachEngines(null,engine)
             }
-        }
+        },
+        readyToEnter: state =>
+            state.multiplayer && state.multiplayer.initConnect < InitConnected.IN_PROGRESS && (state.multiplayer.visibility || jp.join)
     };
 }
 
 exports.load = load
 exports.Visibility = Visibility
+exports.InitConnected = InitConnected

--- a/src/modules/bugout.js
+++ b/src/modules/bugout.js
@@ -17,8 +17,19 @@ const InitConnected = {
     FAILED: 3,
 }
 
+const ColorPref = {
+    BLACK: 1,
+    WHITE: 2,
+    ANY: 3,
+}
+
 const BLACK = "B"
 const WHITE = "W"
+
+const Color = {
+    BLACK,
+    WHITE
+}
 
 /** private to isValidGameId */
 const MIN_ID_LENGTH = 18
@@ -40,41 +51,38 @@ const joinPrivateGameParam = () => {
     }
 }
 
-const playerColor = () => 
-    window.confirm("Press Cancel for White, Press OK for Black") ? BLACK : WHITE
-
 const load = () => {
-    let pc = playerColor()
     let engine = {"name":"Opponent", "path":"/bugout", "args": ""}
     let jp = joinPrivateGameParam()
     return {
         joinPrivateGame: jp,
-        playerColor: pc,
-        start: (cb) => {
-            const STARTUP_WAIT_MS = 1333
-            if (pc === WHITE) {
-                setTimeout(
-                    cb,
-                    STARTUP_WAIT_MS)
-            }
-        },
         engine,
-        attach: appAttachEngines => {
-            if (pc === WHITE) {
+        attach: (appAttachEngines, playerColor) => {
+            if (playerColor === WHITE) {
                 appAttachEngines(engine, null)
             } else {
                 appAttachEngines(null,engine)
             }
         },
         readyToEnter: state => {
+            console.log(`state.multiplayer ${JSON.stringify(state.multiplayer)}`)
+            if (state.multiplayer) {
+                console.log(`\t initConnect\t${state.multiplayer.initConnect}`)
+                console.log(`\t visibility\t${state.multiplayer.visibility}`)
+                console.log(`\t or jp.join\t${jp.join}`)
+                console.log(`\t colorPref\t${state.multiplayer.colorPref}`)
+            }
             return state.multiplayer && (
                 state.multiplayer.initConnect == undefined || 
                 state.multiplayer.initConnect < InitConnected.IN_PROGRESS
-                ) && (state.multiplayer.visibility || jp.join)
-        }
+            ) && (state.multiplayer.visibility || jp.join) && state.multiplayer.colorPref
+        },
+        prefToColor: colorPref => colorPref == ColorPref.BLACK ?  BLACK : WHITE,
     };
 }
 
 exports.load = load
 exports.Visibility = Visibility
 exports.InitConnected = InitConnected
+exports.ColorPref = ColorPref
+exports.Color = Color

--- a/src/modules/bugout.js
+++ b/src/modules/bugout.js
@@ -67,11 +67,6 @@ const load = () => {
             }
         },
         readyToEnter: state => {
-            if (state.multiplayer) {
-                console.log(`ok ${state.multiplayer.initConnect}`)
-            } else {
-                console.log('NOPE')
-            }
             return state.multiplayer && (
                 state.multiplayer.initConnect == undefined || 
                 state.multiplayer.initConnect < InitConnected.IN_PROGRESS

--- a/src/modules/shims/gtp.js
+++ b/src/modules/shims/gtp.js
@@ -261,6 +261,7 @@ class WebSocketController extends EventEmitter {
                 let opponent = letterToPlayer(command.args[0])
                 if (opponent === "BLACK" && this.firstMove) {
                     
+                    console.log(`prov history game ID ${this.gameId}`)
                     let provideHistoryCommand = {
                         "type":"ProvideHistory",
                         "gameId": this.gameId,

--- a/src/modules/shims/gtp.js
+++ b/src/modules/shims/gtp.js
@@ -257,11 +257,9 @@ class WebSocketController extends EventEmitter {
                 })
 
                 this.webSocket.send(JSON.stringify(makeMove))
-            } else if (command.name === "genmove") { // TODO MUST SEND FOR WHITE IN NON_JOIN
+            } else if (command.name === "genmove") {
                 let opponent = letterToPlayer(command.args[0])
                 if (opponent === "BLACK" && this.firstMove) {
-                    
-                    console.log(`prov history game ID ${this.gameId}`)
                     let provideHistoryCommand = {
                         "type":"ProvideHistory",
                         "gameId": this.gameId,

--- a/src/modules/shims/gtp.js
+++ b/src/modules/shims/gtp.js
@@ -257,7 +257,7 @@ class WebSocketController extends EventEmitter {
                 })
 
                 this.webSocket.send(JSON.stringify(makeMove))
-            } else if (command.name === "genmove") {
+            } else if (command.name === "genmove") { // TODO MUST SEND FOR WHITE IN NON_JOIN
                 let opponent = letterToPlayer(command.args[0])
                 if (opponent === "BLACK" && this.firstMove) {
                     


### PR DESCRIPTION
# Multiplayer: add game lobby & color chooser plumbing🚰

This change set ties the multiplayer modal dialog to the connection of the websocket which serves communication between Sabaki and the BUGOUT gateway service.  In the case of a player joining an existing private game via the URL's `?join` query string param, the user is shown a simple dialog with an "OK" button, prior to Sabaki establishing a connection to BUGOUT gateway. 

This changeset also corrects the minimum encoded UUID length so that it works with trivially small UUIDs (all 0s).

- [x] rework attach strategy
- [x] don't crash 💥🧨
- [x] expiate the sin of global state
- [x] support private join URL
- [x] render simple modal when it's a private join URL
- [x] non-joined game with white must request history correctly
- [x] join-private-game white must request history correctly
- [x] use the color choice dialog to select color pref (_no gateway_)
- [x] ditch the old color choice alert
