### PR TITLE
Extend Wait For Opponent modal duration

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -2586,6 +2586,7 @@ class App extends Component {
                                     // the opponent to show up
                                     
                                 } else {
+                                    console.log(`GENERATE MOVE ! ${JSON.stringify(wfpm)}`)
                                     stop()
                                     this.generateMove({ firstMove: true })
                                 }

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -2584,9 +2584,7 @@ class App extends Component {
                                     // not ready for the first move
                                     // as long as we're waiting for
                                     // the opponent to show up
-                                    console.log(`App attach: NO    OP      ! ${JSON.stringify(wfpm)}`)
                                 } else {
-                                    console.log(`App attach: GENERATE MOVE ! ${JSON.stringify(wfpm)}`)
                                     stop()
                                     this.generateMove({ firstMove: true })
                                 }

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -2112,11 +2112,11 @@ class App extends Component {
                     {
                         entryMethod: this.state.multiplayer && this.state.multiplayer.entryMethod,
                         joinPrivateGame: this.bugout.joinPrivateGame,
-                        handleWaitForOpponent: waitForOpponentModal => {
+                        handleWaitForOpponent: data => {
                             this.setState({
                                 multiplayer: {
                                     ...this.state.multiplayer,
-                                    waitForOpponentModal: waitForOpponentModal
+                                    waitForOpponentModal: data
                                 }
                         })
                     }
@@ -2575,18 +2575,18 @@ class App extends Component {
 
                             let stop = () => clearInterval(running)
 
-                            let wfpm = this.state.multiplayer.waitForOpponentModal
-
                             let genMoveAfterWaitForOpponentIsOver = () => {
-                                if ( undefined != wfpm && ( wfpm.gap || wfpm.hasEvent ) ) {
+                                let wfpm = this.state.multiplayer.waitForOpponentModal
+
+                                if ( wfpm && ( wfpm.gap || wfpm.hasEvent ) ) {
                                     // no op
 
                                     // not ready for the first move
                                     // as long as we're waiting for
                                     // the opponent to show up
-                                    
+                                    console.log(`App attach: NO    OP      ! ${JSON.stringify(wfpm)}`)
                                 } else {
-                                    console.log(`GENERATE MOVE ! ${JSON.stringify(wfpm)}`)
+                                    console.log(`App attach: GENERATE MOVE ! ${JSON.stringify(wfpm)}`)
                                     stop()
                                     this.generateMove({ firstMove: true })
                                 }

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -2112,11 +2112,11 @@ class App extends Component {
                     {
                         entryMethod: this.state.multiplayer && this.state.multiplayer.entryMethod,
                         joinPrivateGame: this.bugout.joinPrivateGame,
-                        handleWaitForOpponent: waitForOpponentEvent => {
+                        handleWaitForOpponent: waitForOpponentModal => {
                             this.setState({
                                 multiplayer: {
                                     ...this.state.multiplayer,
-                                    waitForOpponentEvent: waitForOpponentEvent
+                                    waitForOpponentModal: waitForOpponentModal
                                 }
                         })
                     }
@@ -2575,8 +2575,10 @@ class App extends Component {
 
                             let stop = () => clearInterval(running)
 
+                            let wfpm = this.state.multiplayer.waitForOpponentModal
+
                             let genMoveAfterWaitForOpponentIsOver = () => {
-                                if (this.state.multiplayer.waitForOpponentEvent) {
+                                if ( undefined != wfpm && ( wfpm.gap || wfpm.hasEvent ) ) {
                                     // no op
 
                                     // not ready for the first move
@@ -2617,7 +2619,7 @@ class App extends Component {
                 })
             }),
             h(WaitForOpponentModal, {
-                waitForOpponentEvent: this.state.multiplayer && this.state.multiplayer.waitForOpponentEvent
+                data: this.state.multiplayer && this.state.multiplayer.waitForOpponentModal
             }),
             h(ColorChoiceModal, {
                 turnOn: state.multiplayer && state.multiplayer.entryMethod,

--- a/src/components/WaitForOpponentModal.js
+++ b/src/components/WaitForOpponentModal.js
@@ -20,24 +20,25 @@ class WaitForOpponentModal extends Component {
 
     render({ 
         id = 'wait-for-opponent-modal', 
-        waitForOpponentEvent
+        data
     }) {
+        console.log(`wfpm data ${JSON.stringify(data)}`)
         // dfried says a thunk is a thunk is a thunk
         let copyLinkFooter = () => h(Dialog.Footer, null, 
             h(Dialog.FooterButton, 
                 { 
                     accept: true, 
                     onClick: () => 
-                        this.updateClipboard(waitForOpponentEvent.link),
+                        this.updateClipboard(data.event.link),
                 }, 
                 this.state.copied ? 'Copied! ⭐︎' : 'Copy link 🔗')
             )
 
         let emptyFooter = () => h(Dialog.Footer, null)
 
-        let isPublic = () => waitForOpponentEvent.visibility === Visibility.PUBLIC
+        let isPublic = () => data.gap || (data.hasEvent && data.event.visibility === Visibility.PUBLIC)
 
-        return undefined != waitForOpponentEvent ?
+        return undefined != data && (data.gap || data.hasEvent) ?
            h(Dialog,
                 {
                     id,

--- a/src/components/WaitForOpponentModal.js
+++ b/src/components/WaitForOpponentModal.js
@@ -36,7 +36,20 @@ class WaitForOpponentModal extends Component {
 
         let emptyFooter = () => h(Dialog.Footer, null)
 
-        let isPublic = () => data.gap || (data.hasEvent && data.event.visibility === Visibility.PUBLIC)
+        let isPublic = () => data.hasEvent && data.event.visibility === Visibility.PUBLIC
+
+        let body = () => {
+            if (data.gap) {
+                return h(Dialog.Body, null, 'Negotiating game venue...')
+            }
+
+            if (isPublic()) {
+                return h(Dialog.Body, null, 'The game will start once both players are present.')
+            }
+
+            // private
+            return h(Dialog.Body, null, `Click the button below to copy a link to this game onto your clipboard.  You may then paste it to a friend.`)
+        }
 
         return undefined != data && (data.gap || data.hasEvent) ?
            h(Dialog,
@@ -44,11 +57,9 @@ class WaitForOpponentModal extends Component {
                     id,
                     isOpen: true,
                 },
-                h(Dialog.Header, null, isPublic() ? 'Please Wait' : 'Share Private Link'),
-                isPublic() ?
-                    h(Dialog.Body, null, 'The game will start once both players are present') : 
-                    h(Dialog.Body, null, `Click the button below to copy a link to this game onto your clipboard.  You may then paste it to a friend.`),
-                isPublic() ? emptyFooter() : copyLinkFooter()
+                h(Dialog.Header, null, (isPublic() || data.gap) ? 'Please Wait' : 'Share Private Link'),
+                body(),
+                (isPublic() || data.gap) ? emptyFooter() : copyLinkFooter()
             )
         : h('div', { id })
     }

--- a/src/modules/shims/gtp.js
+++ b/src/modules/shims/gtp.js
@@ -183,6 +183,7 @@ class WebSocketController extends EventEmitter {
 
     listenForMove(opponent, resolve) {
         this.resolveMoveMade = resolve
+        
         this.webSocket.addEventListener('message', event => {
             try {
                 let msg = JSON.parse(event.data)
@@ -291,7 +292,6 @@ class GatewayConn {
         this.handleWaitForOpponent = handleWaitForOpponent
     }
 
-
     async reconnect(gameId, resolveMoveMade, board) {
         return new Promise((resolve, reject) => {
             try { 
@@ -321,6 +321,7 @@ class GatewayConn {
                         resolve({error: true})
                     }
                 }
+
                 this.webSocket.send(JSON.stringify(reconnectCommand))
             } catch (err) {
                 reject(err)
@@ -334,17 +335,16 @@ class GatewayConn {
                 'type':'FindPublicGame'
             }
 
-        
             this.webSocket.addEventListener('message', event => {
                 try {
                     let msg = JSON.parse(event.data)
                     
                     if (msg.type === 'GameReady') {
                         resolve(msg)
-                        this.handleWaitForOpponent(undefined)
+                        this.handleWaitForOpponent({ gap: false, hasEvent: false })
                     } else if (msg.type === 'WaitForOpponent') {
                         resolve(msg)
-                        this.handleWaitForOpponent(msg)
+                        this.handleWaitForOpponent({ gap: false, hasEvent: true, event: msg})
                     }
                     // discard any other messages
                 } catch (err) {
@@ -353,6 +353,8 @@ class GatewayConn {
                 }
             })
 
+            // We want to show the modal while we wait for a response from gateway
+            this.handleWaitForOpponent( { gap: true, hasEvent: false })
             this.webSocket.send(JSON.stringify(requestPayload))
         })
     }
@@ -369,11 +371,12 @@ class GatewayConn {
 
                     if (msg.type === 'WaitForOpponent') {
                         resolve(msg)
-                        this.handleWaitForOpponent(msg)
+                        
+                        this.handleWaitForOpponent({ gap: false, hasEvent: true, event: msg})
                     } else if (msg.type === 'GameReady') {
                         // later ...
                         resolve(msg)
-                        this.handleWaitForOpponent(undefined)
+                        this.handleWaitForOpponent({ gap: false, hasEvent: false })
                     }
                     // discard any other messages
                 } catch (err) {
@@ -382,6 +385,8 @@ class GatewayConn {
                 }
             })
 
+            // We want to show the modal while we wait for a response from gateway
+            this.handleWaitForOpponent( { gap: true, hasEvent: false })
             this.webSocket.send(JSON.stringify(requestPayload))
         })
     }
@@ -399,7 +404,7 @@ class GatewayConn {
 
                     if (msg.type === 'GameReady') {
                         resolve(msg)
-                        this.handleWaitForOpponent(undefined)
+                        this.handleWaitForOpponent({ gap: false, hasEvent: false })
                     } else if (msg.type === 'PrivateGameRejected') {
                         resolve(msg)
                     }
@@ -410,6 +415,8 @@ class GatewayConn {
                 }
             })
 
+            // We want to show the modal while we wait for a response from gateway
+            this.handleWaitForOpponent( { gap: true, hasEvent: false })
             this.webSocket.send(JSON.stringify(requestPayload))
         })
     }

--- a/src/modules/shims/gtp.js
+++ b/src/modules/shims/gtp.js
@@ -371,7 +371,6 @@ class GatewayConn {
 
                     if (msg.type === 'WaitForOpponent') {
                         resolve(msg)
-                        
                         this.handleWaitForOpponent({ gap: false, hasEvent: true, event: msg})
                     } else if (msg.type === 'GameReady') {
                         // later ...


### PR DESCRIPTION
This change set alters the `WaitForOpponentModal` to appear immediately after a game lobby choice is clicked.  This prevents the player from placing a stone before the game venue is correctly negotiated.

Resolves https://github.com/Terkwood/BUGOUT/issues/99.