### PR TITLE
Use direct import for material dialog

### DIFF
--- a/src/components/ColorChoiceModal.js
+++ b/src/components/ColorChoiceModal.js
@@ -1,6 +1,9 @@
 const { h, Component } = require('preact')
 
-const { Dialog } = require('preact-material-components')
+// Use direct import to avoid bringing in all the various
+// preact-material-components we don't need
+const Dialog = require('preact-material-components/Dialog')
+
 const { ColorPref } = require('../modules/bugout')
 
 class ColorChoiceModal extends Component {

--- a/src/components/GameLobbyModal.js
+++ b/src/components/GameLobbyModal.js
@@ -1,6 +1,8 @@
 const { h, Component } = require('preact')
 
-const { Dialog } = require('preact-material-components')
+// Use direct import to avoid bringing in all the various
+// preact-material-components we don't need
+const Dialog = require('preact-material-components/Dialog')
 
 const { EntryMethod } = require('../modules/bugout')
 

--- a/src/components/WaitForOpponentModal.js
+++ b/src/components/WaitForOpponentModal.js
@@ -1,6 +1,8 @@
 const { h, Component } = require('preact')
 
-const { Dialog } = require('preact-material-components')
+// Use direct import to avoid bringing in all the various
+// preact-material-components we don't need
+const Dialog = require('preact-material-components/Dialog')
 
 const { Visibility } = require('../modules/bugout')
 


### PR DESCRIPTION
Lowers the bundle size by correctly importing _only_ preact-material-components' `Dialog`. 

Resolves https://github.com/Terkwood/BUGOUT/issues/98.