### PR TITLE
Rename color pref dialog

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -10,8 +10,8 @@ const DrawerManager = require('./DrawerManager')
 
 // BUGOUT 🦹🏻‍ Bundle Bloat Protector
 import BoardSizeModal from './bugout/BoardSizeModal'
-import ColorChoiceModal from './bugout/ColorChoiceModal'
 import GameLobbyModal from './bugout/GameLobbyModal'
+import HumanColorPrefModal from './bugout/HumanColorPrefModal'
 import IdleStatusModal from './bugout/IdleStatusModal'
 import OpponentPassedModal from './bugout/OpponentPassedModal'
 import OpponentQuitModal from './bugout/OpponentQuitModal'
@@ -37,7 +37,7 @@ const setting = remote.require('./setting')
 const sound = require('../modules/sound')
 const bugout = require('../modules/multiplayer/bugout')
 
-const EDITION = 'Doorways'
+const EDITION = 'Pastel Wrench'
 
 class App extends Component {
     constructor() {
@@ -1210,7 +1210,7 @@ class App extends Component {
                 data: state.multiplayer && state.multiplayer.waitForOpponentModal,
                 reconnectDialog: state.multiplayer && state.multiplayer.reconnectDialog
             }),
-            h(ColorChoiceModal, {
+            h(HumanColorPrefModal, {
                 data: state.multiplayer,
                 idleStatus: state.multiplayer && state.multiplayer.idleStatus && state.multiplayer.idleStatus.status,
                 chooseColorPref: colorPref => { 

--- a/src/components/bugout/HumanColorPrefModal.js
+++ b/src/components/bugout/HumanColorPrefModal.js
@@ -5,13 +5,13 @@ import Dialog from 'preact-material-components/Dialog'
 
 const { ColorPref, EntryMethod, IdleStatus } = require('../../modules/multiplayer/bugout')
 
-class ColorChoiceModal extends Component {
+class HumanColorPrefModal extends Component {
     constructor() {
         super()
         this.state = { showDialog: false, turnedOnOnce: false }
     }
 
-    render({ id = "color-choice-modal", data, idleStatus, chooseColorPref }) {
+    render({ id = "human-color-pref-modal", data, idleStatus, chooseColorPref }) {
        
         if (data == undefined) {
             return h('div', { id })
@@ -70,4 +70,4 @@ class ColorChoiceModal extends Component {
 }
 
 
-export default ColorChoiceModal
+export default HumanColorPrefModal


### PR DESCRIPTION
Advances [BUGOUT #67](https://github.com/Terkwood/BUGOUT/issues/67).  We don't want to reuse this color choice modal for bot play, since we don't need the concept of Idle Status.