### PR TITLE
Add wait for bot modal

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -16,6 +16,7 @@ import IdleStatusModal from './bugout/IdleStatusModal'
 import OpponentPassedModal from './bugout/OpponentPassedModal'
 import OpponentQuitModal from './bugout/OpponentQuitModal'
 import ReconnectModal from './bugout/ReconnectModal'
+import WaitForBotModal from './bugout/WaitForBotModal'
 import WaitForOpponentModal from './bugout/WaitForOpponentModal'
 import WaitForYourColorModal from './bugout/WaitForYourColorModal'
 import YourColorChosenModal from './bugout/YourColorChosenModal'
@@ -37,7 +38,7 @@ const setting = remote.require('./setting')
 const sound = require('../modules/sound')
 const bugout = require('../modules/multiplayer/bugout')
 
-const EDITION = 'Garden Clippings'
+const EDITION = 'One Window'
 
 class App extends Component {
     constructor() {
@@ -1243,6 +1244,7 @@ class App extends Component {
             h(IdleStatusModal, { data: state.multiplayer }),
             h(OpponentPassedModal),
             h(OpponentQuitModal),
+            h(WaitForBotModal),
             // ↑ BUGOUT ↑
 
             h(MainView, state),

--- a/src/components/bugout/WaitForBotModal.js
+++ b/src/components/bugout/WaitForBotModal.js
@@ -6,12 +6,16 @@ import Dialog from 'preact-material-components/Dialog'
 class WaitForBotModal extends Component {
     constructor() {
         super()
-        this.state = { isBotAttached: false, isBotPlaying: false }
+        this.state = {
+            isModalRelevant: false,  // does this game even need a bot
+            isBotAttached: false,    // has the backend signaled that bot is ready to play
+            isBotPlaying: false      // is the bot playing the first move
+        }
 
         // From GTP.js
         sabaki.events.on('bugout-wait-for-bot',
-            ({ isBotAttached, isBotPlaying }) => {
-                this.setState({ isBotAttached, isBotPlaying })    
+            ({ isModalRelevant, isBotAttached, isBotPlaying }) => {
+                this.setState({ isModalRelevant, isBotAttached, isBotPlaying })
             }
         )
     }
@@ -20,10 +24,11 @@ class WaitForBotModal extends Component {
         let empty = h('div', { id })
 
         let message = this.state.isBotPlaying ? 
-            'The bot is playing' :
-            'The bot will join'
+            'KataGo is playing.' :
+            'Connecting to KataGo...'
         
-        let showDialog = !this.state.isBotAttached || this.state.isBotPlaying
+        let showDialog = this.state.isModalRelevant &&
+            ( !this.state.isBotAttached || this.state.isBotPlaying )
         
         return showDialog ? h(Dialog,
             {

--- a/src/components/bugout/WaitForBotModal.js
+++ b/src/components/bugout/WaitForBotModal.js
@@ -1,0 +1,40 @@
+const { h, Component } = require('preact')
+
+// 🦹🏻‍ Bundle Bloat Protector
+import Dialog from 'preact-material-components/Dialog'
+
+class WaitForBotModal extends Component {
+    constructor() {
+        super()
+        this.state = { isBotAttached: false, isBotPlaying: false }
+
+        // From GTP.js
+        sabaki.events.on('bugout-wait-for-bot',
+            ({ isBotAttached, isBotPlaying }) => {
+                this.setState({ isBotAttached, isBotPlaying })    
+            }
+        )
+    }
+
+    render({ id = 'wait-for-bot-modal' }) {
+        let empty = h('div', { id })
+
+        let message = this.state.isBotPlaying ? 
+            'The bot is playing' :
+            'The bot will join'
+        
+        let showDialog = !this.state.isBotAttached || this.state.isBotPlaying
+        
+        return showDialog ? h(Dialog,
+            {
+                id,
+                isOpen: true,
+            },
+            h(Dialog.Header, null, 'Please Wait'),
+            h(Dialog.Body, null, message),
+            h(Dialog.Footer, null),
+        ) : empty
+    }
+}
+
+export default WaitForBotModal


### PR DESCRIPTION
This creates a modal dialog which will tell the user to wait for KataGo to join, or to wait for KataGo to finish its first move.

The functionality isn't yet used by the app.  It can easily be triggered by the main `EventEmitter`.