### PR TITLE
Allow multiple entry methods for board size dialog

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,4 +1,4 @@
-const EDITION = 'Please Stoat'
+const EDITION = 'Toast'
 
 const EventEmitter = require('events')
 const {ipcRenderer, remote} = require('electron')

--- a/src/components/bugout/BoardSizeModal.js
+++ b/src/components/bugout/BoardSizeModal.js
@@ -5,6 +5,8 @@ import Dialog from 'preact-material-components/Dialog'
 
 const { BoardSize, EntryMethod } = require('../../modules/multiplayer/bugout')
 
+const ALLOWED_ENTRY_METHODS = [ EntryMethod.CREATE_PRIVATE, EntryMethod.PLAY_BOT ]
+
 class BoardSizeModal extends Component {
     constructor() {
         super()
@@ -21,7 +23,8 @@ class BoardSizeModal extends Component {
 
         let { showDialog, turnedOnOnce } = this.state
 
-        let turnOn = entryMethod !== undefined && entryMethod == EntryMethod.CREATE_PRIVATE
+        let turnOn = entryMethod !== undefined &&
+            ALLOWED_ENTRY_METHODS.includes(entryMethod)
 
         let hide = !((turnOn && !turnedOnOnce) || showDialog)
 


### PR DESCRIPTION
Refactors the board size dialog to allow multiple entry methods.  From the human player's perspective, current behavior is unchanged.

Advances [BUGOUT #67](https://github.com/Terkwood/BUGOUT/issues/67).